### PR TITLE
Use prod branch for cookiecutter templates

### DIFF
--- a/strudel-cli/src/strudel/callbacks.py
+++ b/strudel-cli/src/strudel/callbacks.py
@@ -7,7 +7,7 @@ defaults = {
     "create-app": {
         "name": "",
         "output_dir": "",
-        "branch": "main",
+        "branch": "prod",
         "config": "",
         "verbose": 0
     },
@@ -15,7 +15,7 @@ defaults = {
         "name": "",
         "template": "",
         "output_dir": "src/app",
-        "branch": "main",
+        "branch": "prod",
         "config": "",
         "verbose": 0
     }


### PR DESCRIPTION
The strudel CLI will now pull cookiecutter templates from the prod branch instead of main. This makes it so that we can merge changes into the main branch without impacting the released version of strudel-cli.