### PR TITLE
Fix bugs causing issues with data paths

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,5 +19,3 @@ jobs:
           working-directory: strudel-taskflows
           browser: chrome
           start: npm start
-        env:
-          VITE_BASE_URL: /strudel-kit/demo/

--- a/strudel-cookiecutter/base/{@cookiecutter.name@}/cypress.config.ts
+++ b/strudel-cookiecutter/base/{@cookiecutter.name@}/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:5175/strudel-kit/demo/',
+    baseUrl: 'http://localhost:5175/',
     specPattern: ['cypress/e2e/**/*.cy.{js,jsx,ts,tsx}', 'src/**/*.cy.{js,jsx,ts,tsx}']
   },
 });

--- a/strudel-cookiecutter/base/{@cookiecutter.name@}/package.json
+++ b/strudel-cookiecutter/base/{@cookiecutter.name@}/package.json
@@ -44,8 +44,6 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
     "gh-pages": "^6.1.1",
-    "typedoc": "^0.25.13",
-    "typedoc-plugin-markdown": "^4.0.0",
     "typescript": "^5.2.2",
     "vite": "^5.2.10"
   },

--- a/strudel-cookiecutter/base/{@cookiecutter.name@}/src/components/Footer.tsx
+++ b/strudel-cookiecutter/base/{@cookiecutter.name@}/src/components/Footer.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { config } from '../../strudel.config';
 import { AppLink } from './AppLink';
 import { ImageWrapper } from './ImageWrapper';
+import { cleanPath } from '../utils/queryParams.utils';
 
 /**
  * Bottom footer component
@@ -38,7 +39,7 @@ export const Footer: React.FC = () => {
               {config.footer.image && (
                 <AppLink to="/">
                   <ImageWrapper height={60}>
-                    <img src={`${import.meta.env.BASE_URL}/${config.footer.image}`} />
+                    <img src={cleanPath(`${import.meta.env.BASE_URL}/${config.footer.image}`)} />
                   </ImageWrapper>
                 </AppLink>
               )}

--- a/strudel-cookiecutter/base/{@cookiecutter.name@}/src/components/TopBar.tsx
+++ b/strudel-cookiecutter/base/{@cookiecutter.name@}/src/components/TopBar.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { AppLink } from './AppLink';
 import { config } from '../../strudel.config';
 import { ImageWrapper } from './ImageWrapper';
+import { cleanPath } from '../utils/queryParams.utils';
 
 /**
  * Top navigation bar component
@@ -33,7 +34,7 @@ export const TopBar: React.FC = () => {
             )}
             {config.navbar.logo && (
               <ImageWrapper height={30}>
-                <img src={`${import.meta.env.BASE_URL}/${config.navbar.logo}`} />
+                <img src={cleanPath(`${import.meta.env.BASE_URL}/${config.navbar.logo}`)} />
               </ImageWrapper>
             )}
           </AppLink>

--- a/strudel-cookiecutter/base/{@cookiecutter.name@}/src/utils/queryParams.utils.ts
+++ b/strudel-cookiecutter/base/{@cookiecutter.name@}/src/utils/queryParams.utils.ts
@@ -111,6 +111,10 @@ export const cleanUrl = (url: string) => {
   return url.replace(/([^:]\/)\/+/g, "$1");
 }
 
+export const cleanPath = (url: string) => {
+  return url.replace(/\/\//g, "/");
+}
+
 /**
  * Fetch data from a local CSV, TSV, or JSON, or an external API
  * that returns JSON.
@@ -120,7 +124,8 @@ export const fetchData = async (dataSource: string) => {
   const base = document.querySelector('base')?.getAttribute('href') ?? '';
   // Use the VITE_BASE_URL env variable to specify a path prefix that 
   // should be added to routes and local requests
-  const basename = base + import.meta.env.VITE_BASE_URL;
+  const basePath = import.meta.env.VITE_BASE_URL || '';
+  const basename = base + basePath;
   const fileExtension = dataSource.split('.').pop();
   const isExternal = dataSource.startsWith('http');
   const dataSourcePath = isExternal ? cleanUrl(dataSource) : cleanUrl(`${basename}/${dataSource}`);

--- a/strudel-cookiecutter/base/{@cookiecutter.name@}/src/utils/useDataFromSource.tsx
+++ b/strudel-cookiecutter/base/{@cookiecutter.name@}/src/utils/useDataFromSource.tsx
@@ -16,7 +16,8 @@ export const useDataFromSource = (dataSource: string): any => {
    * Use the VITE_BASE_URL env variable to specify a path prefix that 
    * should be added to routes and local requests
    */
-  const basename = base + import.meta.env.VITE_BASE_URL;
+  const basePath = import.meta.env.VITE_BASE_URL || '';
+  const basename = base + basePath;
 
   useEffect(() => {
     const fetchData = async () => {

--- a/strudel-cookiecutter/compare-data/{@cookiecutter.name@}/_config/taskflow.config.ts
+++ b/strudel-cookiecutter/compare-data/{@cookiecutter.name@}/_config/taskflow.config.ts
@@ -18,7 +18,7 @@ export const taskflow: CompareDataConfig = {
       /**
        * Source of the data for the initial list of items. 
        */
-      source: "default/compare-data/scenarios.json",
+      source: "data/default/compare-data/scenarios.json",
       /**
        * Field name for the unique ID in the data source.
        */

--- a/strudel-cookiecutter/contribute-data/{@cookiecutter.name@}/_config/taskflow.config.ts
+++ b/strudel-cookiecutter/contribute-data/{@cookiecutter.name@}/_config/taskflow.config.ts
@@ -6,7 +6,7 @@ export const taskflow: ContributeDataConfig = {
       /**
        * Source of the data for the initial list of datasets on the portal page. 
        */
-      source: "default/contribute-data/contributor_datasets.json",
+      source: "data/default/contribute-data/contributor_datasets.json",
       /**
        * Name of the field in the data that represents a unique identifier for each record. 
        */

--- a/strudel-cookiecutter/monitor-activities/{@cookiecutter.name@}/_config/taskflow.config.ts
+++ b/strudel-cookiecutter/monitor-activities/{@cookiecutter.name@}/_config/taskflow.config.ts
@@ -6,7 +6,7 @@ export const taskflow: MonitorActivitiesConfig = {
       /**
        * Source of the data for the initial list of items. 
        */
-      source: "default/monitor-activities/experiments.json",
+      source: "data/default/monitor-activities/experiments.json",
       /**
        * Field name for the unique ID in the data source.
        */

--- a/strudel-cookiecutter/run-computation/{@cookiecutter.name@}/_config/taskflow.config.ts
+++ b/strudel-cookiecutter/run-computation/{@cookiecutter.name@}/_config/taskflow.config.ts
@@ -18,7 +18,7 @@ export const taskflow: RunComputationConfig = {
       /**
        * Source of the data for the initial list of items.
        */
-      source: "default/run-computation/list.json",
+      source: "data/default/run-computation/list.json",
       /**
        * Field name for the unique ID in the data source.
        */
@@ -28,7 +28,7 @@ export const taskflow: RunComputationConfig = {
       /**
        * Source of the data for the table on the inputs page.
        */
-      source: "default/run-computation/inputs.json",
+      source: "data/default/run-computation/inputs.json",
       /**
        * Field name for the unique ID in the data source.
        */
@@ -40,7 +40,7 @@ export const taskflow: RunComputationConfig = {
        * The return format must be compatible with Plotly's data attribue. 
        * See the [Plotly Figure Reference](https://plotly.com/javascript/reference/index/) for more details.
        */
-      source: "default/run-computation/results_line_chart.json"
+      source: "data/default/run-computation/results_line_chart.json"
     },
     barChart: {
       /**
@@ -48,13 +48,13 @@ export const taskflow: RunComputationConfig = {
        * The return format must be compatible with Plotly's data attribue. 
        * See the [Plotly Figure Reference](https://plotly.com/javascript/reference/index/) for more details.
        */
-      source: "default/run-computation/results_bar_chart.json"
+      source: "data/default/run-computation/results_bar_chart.json"
     },
     results: {
       /**
        * Source of the data for the table on the results page.
        */
-      source: "default/run-computation/results_table.json",
+      source: "data/default/run-computation/results_table.json",
       /**
        * Field name for the unique ID in the data source.
        */

--- a/strudel-cookiecutter/search-data-repositories/{@cookiecutter.name@}/_config/taskflow.config.ts
+++ b/strudel-cookiecutter/search-data-repositories/{@cookiecutter.name@}/_config/taskflow.config.ts
@@ -6,7 +6,7 @@ export const taskflow: SearchDataRepositoriesConfig = {
       /**
        * Source of the data for the initial list of items on the main page.
        */
-      source: "default/search-data-repositories/datasets.json",
+      source: "data/default/search-data-repositories/datasets.json",
       /**
        * Field name for the unique ID in the data source.
        */

--- a/strudel-taskflows/cypress.config.ts
+++ b/strudel-taskflows/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:5175/strudel-kit/demo/',
+    baseUrl: 'http://localhost:5175/',
     specPattern: ['cypress/e2e/**/*.cy.{js,jsx,ts,tsx}', 'src/**/*.cy.{js,jsx,ts,tsx}']
   },
 });

--- a/strudel-taskflows/package-lock.json
+++ b/strudel-taskflows/package-lock.json
@@ -39,8 +39,6 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
         "gh-pages": "^6.1.1",
-        "typedoc": "^0.25.13",
-        "typedoc-plugin-markdown": "^4.0.0",
         "typescript": "^5.2.2",
         "vite": "^5.2.10"
       },
@@ -2610,12 +2608,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/ansi-sequence-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
-      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -5798,12 +5790,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
-      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
-      "dev": true
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -6119,12 +6105,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true
-    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -6196,18 +6176,6 @@
       },
       "engines": {
         "node": ">=6.4.0"
-      }
-    },
-    "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/math-log2": {
@@ -7523,18 +7491,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shiki": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
-      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-sequence-parser": "^1.1.0",
-        "jsonc-parser": "^3.2.0",
-        "vscode-oniguruma": "^1.7.0",
-        "vscode-textmate": "^8.0.0"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -8078,36 +8034,6 @@
         "dup": "^1.0.0"
       }
     },
-    "node_modules/typedoc": {
-      "version": "0.25.13",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
-      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
-      "dev": true,
-      "dependencies": {
-        "lunr": "^2.3.9",
-        "marked": "^4.3.0",
-        "minimatch": "^9.0.3",
-        "shiki": "^0.14.7"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
-      }
-    },
-    "node_modules/typedoc-plugin-markdown": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.0.0.tgz",
-      "integrity": "sha512-7cNKIGxGq1w9IvwWbm6jAASUCvlJeaANJXCOH+Fcvz2JrNIIMVbRu4j2Nq2zpDDaBHsrUmKVaz+F5vroMU8u4A==",
-      "dev": true,
-      "peerDependencies": {
-        "typedoc": "0.25.x"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
@@ -8295,18 +8221,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
-    },
-    "node_modules/vscode-textmate": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-      "dev": true
     },
     "node_modules/vt-pbf": {
       "version": "3.1.3",

--- a/strudel-taskflows/package.json
+++ b/strudel-taskflows/package.json
@@ -44,8 +44,6 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
     "gh-pages": "^6.1.1",
-    "typedoc": "^0.25.13",
-    "typedoc-plugin-markdown": "^4.0.0",
     "typescript": "^5.2.2",
     "vite": "^5.2.10"
   },

--- a/strudel-taskflows/src/components/Footer.tsx
+++ b/strudel-taskflows/src/components/Footer.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { config } from '../../strudel.config';
 import { AppLink } from './AppLink';
 import { ImageWrapper } from './ImageWrapper';
+import { cleanPath } from '../utils/queryParams.utils';
 
 /**
  * Bottom footer component
@@ -38,7 +39,7 @@ export const Footer: React.FC = () => {
               {config.footer.image && (
                 <AppLink to="/">
                   <ImageWrapper height={60}>
-                    <img src={`${import.meta.env.BASE_URL}/${config.footer.image}`} />
+                    <img src={cleanPath(`${import.meta.env.BASE_URL}/${config.footer.image}`)} />
                   </ImageWrapper>
                 </AppLink>
               )}

--- a/strudel-taskflows/src/components/TopBar.tsx
+++ b/strudel-taskflows/src/components/TopBar.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { AppLink } from './AppLink';
 import { config } from '../../strudel.config';
 import { ImageWrapper } from './ImageWrapper';
+import { cleanPath } from '../utils/queryParams.utils';
 
 /**
  * Top navigation bar component
@@ -33,7 +34,7 @@ export const TopBar: React.FC = () => {
             )}
             {config.navbar.logo && (
               <ImageWrapper height={30}>
-                <img src={`${import.meta.env.BASE_URL}/${config.navbar.logo}`} />
+                <img src={cleanPath(`${import.meta.env.BASE_URL}/${config.navbar.logo}`)} />
               </ImageWrapper>
             )}
           </AppLink>

--- a/strudel-taskflows/src/pages/compare-data/_config/taskflow.config.ts
+++ b/strudel-taskflows/src/pages/compare-data/_config/taskflow.config.ts
@@ -18,7 +18,7 @@ export const taskflow: CompareDataConfig = {
       /**
        * Source of the data for the initial list of items. 
        */
-      source: "default/compare-data/scenarios.json",
+      source: "data/default/compare-data/scenarios.json",
       /**
        * Field name for the unique ID in the data source.
        */

--- a/strudel-taskflows/src/pages/contribute-data/_config/taskflow.config.ts
+++ b/strudel-taskflows/src/pages/contribute-data/_config/taskflow.config.ts
@@ -6,7 +6,7 @@ export const taskflow: ContributeDataConfig = {
       /**
        * Source of the data for the initial list of datasets on the portal page. 
        */
-      source: "default/contribute-data/contributor_datasets.json",
+      source: "data/default/contribute-data/contributor_datasets.json",
       /**
        * Name of the field in the data that represents a unique identifier for each record. 
        */

--- a/strudel-taskflows/src/pages/monitor-activities/_config/taskflow.config.ts
+++ b/strudel-taskflows/src/pages/monitor-activities/_config/taskflow.config.ts
@@ -6,7 +6,7 @@ export const taskflow: MonitorActivitiesConfig = {
       /**
        * Source of the data for the initial list of items. 
        */
-      source: "default/monitor-activities/experiments.json",
+      source: "data/default/monitor-activities/experiments.json",
       /**
        * Field name for the unique ID in the data source.
        */

--- a/strudel-taskflows/src/pages/run-computation/_config/taskflow.config.ts
+++ b/strudel-taskflows/src/pages/run-computation/_config/taskflow.config.ts
@@ -18,7 +18,7 @@ export const taskflow: RunComputationConfig = {
       /**
        * Source of the data for the initial list of items.
        */
-      source: "default/run-computation/list.json",
+      source: "data/default/run-computation/list.json",
       /**
        * Field name for the unique ID in the data source.
        */
@@ -28,7 +28,7 @@ export const taskflow: RunComputationConfig = {
       /**
        * Source of the data for the table on the inputs page.
        */
-      source: "default/run-computation/inputs.json",
+      source: "data/default/run-computation/inputs.json",
       /**
        * Field name for the unique ID in the data source.
        */
@@ -40,7 +40,7 @@ export const taskflow: RunComputationConfig = {
        * The return format must be compatible with Plotly's data attribue. 
        * See the [Plotly Figure Reference](https://plotly.com/javascript/reference/index/) for more details.
        */
-      source: "default/run-computation/results_line_chart.json"
+      source: "data/default/run-computation/results_line_chart.json"
     },
     barChart: {
       /**
@@ -48,13 +48,13 @@ export const taskflow: RunComputationConfig = {
        * The return format must be compatible with Plotly's data attribue. 
        * See the [Plotly Figure Reference](https://plotly.com/javascript/reference/index/) for more details.
        */
-      source: "default/run-computation/results_bar_chart.json"
+      source: "data/default/run-computation/results_bar_chart.json"
     },
     results: {
       /**
        * Source of the data for the table on the results page.
        */
-      source: "default/run-computation/results_table.json",
+      source: "data/default/run-computation/results_table.json",
       /**
        * Field name for the unique ID in the data source.
        */

--- a/strudel-taskflows/src/pages/search-data-repositories/_config/taskflow.config.ts
+++ b/strudel-taskflows/src/pages/search-data-repositories/_config/taskflow.config.ts
@@ -6,7 +6,7 @@ export const taskflow: SearchDataRepositoriesConfig = {
       /**
        * Source of the data for the initial list of items on the main page.
        */
-      source: "default/search-data-repositories/datasets.json",
+      source: "data/default/search-data-repositories/datasets.json",
       /**
        * Field name for the unique ID in the data source.
        */

--- a/strudel-taskflows/src/utils/queryParams.utils.ts
+++ b/strudel-taskflows/src/utils/queryParams.utils.ts
@@ -124,7 +124,8 @@ export const fetchData = async (dataSource: string) => {
   const base = document.querySelector('base')?.getAttribute('href') ?? '';
   // Use the VITE_BASE_URL env variable to specify a path prefix that 
   // should be added to routes and local requests
-  const basename = base + import.meta.env.VITE_BASE_URL;
+  const basePath = import.meta.env.VITE_BASE_URL || '';
+  const basename = base + basePath;
   const fileExtension = dataSource.split('.').pop();
   const isExternal = dataSource.startsWith('http');
   const dataSourcePath = isExternal ? cleanUrl(dataSource) : cleanUrl(`${basename}/${dataSource}`);

--- a/strudel-taskflows/src/utils/queryParams.utils.ts
+++ b/strudel-taskflows/src/utils/queryParams.utils.ts
@@ -111,6 +111,10 @@ export const cleanUrl = (url: string) => {
   return url.replace(/([^:]\/)\/+/g, "$1");
 }
 
+export const cleanPath = (url: string) => {
+  return url.replace(/\/\//g, "/");
+}
+
 /**
  * Fetch data from a local CSV, TSV, or JSON, or an external API
  * that returns JSON.

--- a/strudel-taskflows/src/utils/useDataFromSource.tsx
+++ b/strudel-taskflows/src/utils/useDataFromSource.tsx
@@ -16,7 +16,8 @@ export const useDataFromSource = (dataSource: string): any => {
    * Use the VITE_BASE_URL env variable to specify a path prefix that 
    * should be added to routes and local requests
    */
-  const basename = base + import.meta.env.VITE_BASE_URL;
+  const basePath = import.meta.env.VITE_BASE_URL || '';
+  const basename = base + basePath;
 
   useEffect(() => {
     const fetchData = async () => {


### PR DESCRIPTION
Data fetching for datasets and images was not working without the VITE_BASE_URL env variable. Now, this env variable is optional and data can be fetched without it be specified. There were also some bugs with how paths were being cleaned resulting in doubles slashes.