### PR TITLE
Add algolia search to docs

### DIFF
--- a/docs/docs/introduction.mdx
+++ b/docs/docs/introduction.mdx
@@ -1,10 +1,14 @@
 ---
-title: 'Introduction'
+title: "Introduction"
 slug: /
 ---
 
-import { Grid } from '@mui/material';
-import { LinkCard } from '@site/src/components/LinkCard';
+import { Grid } from "@mui/material";
+import { LinkCard } from "@site/src/components/LinkCard";
+
+<head>
+  <meta name="algolia-site-verification" content="16A9CD3EED0F32F0" />
+</head>
 
 # STRUDEL Kit
 
@@ -13,12 +17,12 @@ Welcome to the STRUDEL Kit Docs! STRUDEL Kit is a web development toolkit for bu
 Visit [strudel.science](https://strudel.science) for more information about the STRUDEL project.
 
 ### Key Features
+
 - Fully customizable React templates for common Task Flows in scientific software
 - CLI for bootstrapping React apps that are template-ready
 - Consistent user experience
 - Automated file-based routing
 - Configuration-based customization
-
 
 ## How does it work?
 
@@ -33,7 +37,7 @@ The **base app** provides the basic scaffolding you need to get started building
       image={<img src="img/react.png" />}
       label="React"
       description="Component-based web UI library"
-    /> 
+    />
   </Grid>
   <Grid item sm={4}>
     <LinkCard
@@ -41,7 +45,7 @@ The **base app** provides the basic scaffolding you need to get started building
       image={<img src="img/typescript.svg" />}
       label="TypeScript"
       description="JavaScript with syntax for types"
-    /> 
+    />
   </Grid>
   <Grid item sm={4}>
     <LinkCard
@@ -49,7 +53,7 @@ The **base app** provides the basic scaffolding you need to get started building
       image={<img src="img/vite.png" />}
       label="Vite"
       description="Modern frontend build tool"
-    /> 
+    />
   </Grid>
   <Grid item sm={4}>
     <LinkCard
@@ -57,7 +61,7 @@ The **base app** provides the basic scaffolding you need to get started building
       image={<img src="img/strudel-logo-icon.png" />}
       label="STRUDEL Components"
       description="Custom components inside the base app"
-    /> 
+    />
   </Grid>
   <Grid item sm={4}>
     <LinkCard
@@ -65,7 +69,7 @@ The **base app** provides the basic scaffolding you need to get started building
       image={<img src="img/material-ui.png" />}
       label="Material UI"
       description="Low-level component library"
-    /> 
+    />
   </Grid>
   <Grid item sm={4}>
     <LinkCard
@@ -73,7 +77,7 @@ The **base app** provides the basic scaffolding you need to get started building
       image={<img src="img/plotly.png" />}
       label="Plotly.js"
       description="Declarative data visualization library"
-    /> 
+    />
   </Grid>
   <Grid item sm={4}>
     <LinkCard
@@ -81,14 +85,14 @@ The **base app** provides the basic scaffolding you need to get started building
       image={<img src="img/generouted.svg" />}
       label="Generouted"
       description="Automated file-based routing library"
-    /> 
+    />
   </Grid>
   <Grid item sm={4}>
     <LinkCard
       href="https://react.dev/reference/react/useContext"
       label="React Context API"
       description="React's first-party state management"
-    /> 
+    />
   </Grid>
 </Grid>
 
@@ -119,7 +123,7 @@ Before getting started, we recommend having some familiarity with the command li
       target="_self"
       label="Installation"
       description="Install everything you need to get started"
-    /> 
+    />
   </Grid>
   <Grid item sm={4}>
     <LinkCard
@@ -127,7 +131,7 @@ Before getting started, we recommend having some familiarity with the command li
       target="_self"
       label="First Steps"
       description="Learn the basics with some guidance"
-    /> 
+    />
   </Grid>
   <Grid item sm={4}>
     <LinkCard
@@ -135,14 +139,14 @@ Before getting started, we recommend having some familiarity with the command li
       target="_self"
       label="Tutorial"
       description="A full tutorial on building with STRUDEL"
-    /> 
+    />
   </Grid>
-    <Grid item sm={4}>
+  <Grid item sm={4}>
     <LinkCard
       href="/strudel-kit/docs/getting-started/quickstart"
       target="_self"
       label="Quickstart"
       description="Jump straight into the code"
-    /> 
+    />
   </Grid>
 </Grid>

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,10 +1,10 @@
-import {themes as prismThemes} from 'prism-react-renderer';
-import type {Config} from '@docusaurus/types';
-import type * as Preset from '@docusaurus/preset-classic';
+import { themes as prismThemes } from "prism-react-renderer";
+import type { Config } from "@docusaurus/types";
+import type * as Preset from "@docusaurus/preset-classic";
 
 const options: any = {
   // pass in a single string or an array of strings
-  src: ['../strudel-demo-app/src/components/**/*.tsx'],
+  src: ["../strudel-demo-app/src/components/**/*.tsx"],
   // parserOptions: {
   //   // pass parserOptions to react-docgen-typescript
   //   // here is a good starting point which filters out all
@@ -20,124 +20,125 @@ const options: any = {
 };
 
 const config: Config = {
-  title: 'STRUDEL Kit',
-  tagline: 'Create user-centered software for scientific communities',
-  favicon: 'img/favicon.png',
-  url: 'https://strudel.science',
-  baseUrl: '/strudel-kit/docs/',
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  title: "STRUDEL Kit",
+  tagline: "Create user-centered software for scientific communities",
+  favicon: "img/favicon.png",
+  url: "https://strudel.science",
+  baseUrl: "/strudel-kit/docs/",
+  onBrokenLinks: "warn",
+  onBrokenMarkdownLinks: "warn",
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en'],
+    defaultLocale: "en",
+    locales: ["en"],
   },
   presets: [
     [
-      'classic',
+      "classic",
       {
         docs: {
-          routeBasePath: '/',
-          sidebarPath: './sidebars.ts',
-          editUrl: 'https://github.com/strudel-science/strudel-kit/tree/main/docs',
+          routeBasePath: "/",
+          sidebarPath: "./sidebars.ts",
+          editUrl:
+            "https://github.com/strudel-science/strudel-kit/tree/main/docs",
         },
         blog: false,
         theme: {
-          customCss: './src/css/custom.css',
+          customCss: "./src/css/custom.css",
         },
       } satisfies Preset.Options,
     ],
   ],
   themeConfig: {
-    image: 'img/strudel-logo-header.png',
+    image: "img/strudel-logo-header.png",
     colorMode: {
-      defaultMode: 'dark',
+      defaultMode: "dark",
     },
     docs: {
       sidebar: {
         autoCollapseCategories: true,
-      }
+      },
     },
     navbar: {
-      title: 'STRUDEL Kit',
+      title: "STRUDEL Kit",
       logo: {
-        alt: 'My Site Logo',
-        src: 'img/strudel-logo-icon.png',
+        alt: "My Site Logo",
+        src: "img/strudel-logo-icon.png",
       },
       items: [
         {
-          type: 'docSidebar',
-          sidebarId: 'mainSidebar',
-          position: 'left',
-          label: 'Documentation',
+          type: "docSidebar",
+          sidebarId: "mainSidebar",
+          position: "left",
+          label: "Documentation",
         },
         {
-          href: 'https://github.com/strudel-science/strudel-kit',
-          label: 'GitHub',
-          position: 'right',
+          href: "https://github.com/strudel-science/strudel-kit",
+          label: "GitHub",
+          position: "right",
         },
       ],
     },
     footer: {
-      style: 'dark',
+      style: "dark",
       logo: {
-        alt: 'STRUDEL Logo',
-        src: 'img/strudel-logo-header.png',
-        href: 'https://strudel.science',
+        alt: "STRUDEL Logo",
+        src: "img/strudel-logo-header.png",
+        href: "https://strudel.science",
         height: 75,
       },
       links: [
         {
-          title: 'Docs',
+          title: "Docs",
           items: [
             {
-              label: 'Getting Started',
-              to: '/',
+              label: "Getting Started",
+              to: "/",
             },
             {
-              label: 'Guides',
-              to: '/guides/combine-sections',
+              label: "Guides",
+              to: "/guides/combine-sections",
             },
             {
-              label: 'Task Flows',
-              to: '/task-flows/overview',
+              label: "Task Flows",
+              to: "/task-flows/overview",
             },
             {
-              label: 'Components',
-              to: '/components/overview',
+              label: "Components",
+              to: "/components/overview",
             },
             {
-              label: 'CLI',
-              to: '/cli/reference',
+              label: "CLI",
+              to: "/cli/reference",
             },
           ],
         },
         {
-          title: 'Community',
+          title: "Community",
           items: [
             {
-              label: 'GitHub Discussions',
-              href: 'https://github.com/orgs/strudel-science/discussions/',
+              label: "GitHub Discussions",
+              href: "https://github.com/orgs/strudel-science/discussions/",
             },
             {
-              label: 'Join our mailing list',
-              href: 'mailto:strudel-community+subscribe@lbl.gov',
+              label: "Join our mailing list",
+              href: "mailto:strudel-community+subscribe@lbl.gov",
             },
             {
-              label: 'Email us',
-              href: 'mailto:strudel@lbl.gov',
+              label: "Email us",
+              href: "mailto:strudel@lbl.gov",
             },
           ],
         },
         {
-          title: 'More',
+          title: "More",
           items: [
             {
-              label: 'Events',
-              href: 'https://strudel.science/engage/events/',
+              label: "Events",
+              href: "https://strudel.science/engage/events/",
             },
             {
-              label: 'Task Flow Designs',
-              href: 'https://strudel.science/design-system/task-flows/overview/',
+              label: "Task Flow Designs",
+              href: "https://strudel.science/design-system/task-flows/overview/",
             },
           ],
         },
@@ -153,16 +154,23 @@ const config: Config = {
        * The position of the live playground, above or under the editor
        * Possible values: "top" | "bottom"
        */
-      playgroundPosition: 'top',
+      playgroundPosition: "top",
+    },
+    algolia: {
+      // The application ID provided by Algolia
+      appId: "CFT2374PW2",
+      // Public API key: it is safe to commit it
+      apiKey: "bcc5c2c8126b8fc2f4f7561a4517467a",
+      indexName: "strudel",
+      // Optional: path for search page that enabled by default (`false` to disable it)
+      searchPagePath: "search",
     },
   } satisfies Preset.ThemeConfig,
   themes: [
-    '@saucelabs/theme-github-codeblock',
-    '@docusaurus/theme-live-codeblock'
+    "@saucelabs/theme-github-codeblock",
+    "@docusaurus/theme-live-codeblock",
   ],
-  plugins: [
-    ['docusaurus-plugin-react-docgen-typescript', options],
-  ]
+  plugins: [["docusaurus-plugin-react-docgen-typescript", options]],
 };
 
 export default config;


### PR DESCRIPTION
Adds the algolia configuration and meta tag to the docs site. This should allow algolia to crawl our site and make the search component functional.