### PR TITLE
Fix raw loader paths in docs

### DIFF
--- a/docs/docs/getting-started/first-steps.mdx
+++ b/docs/docs/getting-started/first-steps.mdx
@@ -3,11 +3,11 @@ title: 'First Steps'
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import ConfigJson from '!!raw-loader!../../../strudel-taskflows/strudel.config';
+import ConfigJson from '!!raw-loader!../../../strudel.config';
 import { Grid } from '@mui/material';
 import { LinkCard } from '@site/src/components/LinkCard';
 
-This page will cover the basic workflow for using STRUDEL Kit to build a web UI. 
+This page will cover the basic workflow for using STRUDEL Kit to build a web UI.
 
 There are three primary steps to using STRUDEL Kit:
 
@@ -25,7 +25,7 @@ strudel --version
 
 ## Build a base app
 
-The first step to getting started with the STRUDEL Kit is to build a base app using the `create-app` command. 
+The first step to getting started with the STRUDEL Kit is to build a base app using the `create-app` command.
 
 ```bash
 strudel create-app my-app
@@ -33,7 +33,7 @@ strudel create-app my-app
 
 This will generate a new directory called `my-app` with the basic scaffolding for a STRUDEL-powered React app. The name `my-app` can be replaced with any name you like. It's typical to use all lowercase kebab-case for project names.
 
-The app comes pre-baked with all libraries in the [STRUDEL Tech Stack](#) as well as a set of custom components that are used across the app and the Task Flow templates. 
+The app comes pre-baked with all libraries in the [STRUDEL Tech Stack](#) as well as a set of custom components that are used across the app and the Task Flow templates.
 
 ### Base app files breakdown
 
@@ -81,9 +81,11 @@ Your app should now be running at http://localhost:5173. At this point your app 
 
 ### Configure up your app
 
-STRUDEL Kit makes use of a simple configuration file at the root of your app called `strudel.config.ts`. Here you can set a few basic global options and content items like a site logo and navigation links. 
+STRUDEL Kit makes use of a simple configuration file at the root of your app called `strudel.config.ts`. Here you can set a few basic global options and content items like a site logo and navigation links.
 
-<CodeBlock language="ts" title="strudel.config.ts">{ConfigJson}</CodeBlock>
+<CodeBlock language="ts" title="strudel.config.ts">
+  {ConfigJson}
+</CodeBlock>
 
 You can also customize the global theme in `src/theme.tsx`. This uses the MUI theme object to make app-wide style adjustments. See [MUI's theme documentation](https://mui.com/material-ui/customization/default-theme/).
 
@@ -133,20 +135,20 @@ If you'd like to customize the Task Flow beyond what you can do with the configu
       href="/strudel-kit/docs/guides/tutorials/basic-app-with-strudel/customize-taskflow"
       target="_self"
       label="Customize Your Task Flow"
-    /> 
+    />
   </Grid>
   <Grid item sm={4}>
     <LinkCard
       href="/strudel-kit/docs/guides/combine-sections"
       target="_self"
       label="Combining Sections"
-    /> 
+    />
   </Grid>
   <Grid item sm={4}>
     <LinkCard
       href="/strudel-kit/docs/guides/connect-task-flows-together"
       target="_self"
       label="Connecting Task Flows"
-    /> 
+    />
   </Grid>
 </Grid>

--- a/docs/docs/task-flows/compare-data.mdx
+++ b/docs/docs/task-flows/compare-data.mdx
@@ -3,7 +3,7 @@ title: 'Compare Data'
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import ConfigJson from '!!raw-loader!../../../strudel-taskflows/src/pages/compare-data/_config/taskflow.config';
+import ConfigJson from '!!raw-loader!../../../src/pages/compare-data/_config/taskflow.config';
 
 # Compare Data
 
@@ -60,4 +60,6 @@ New record page of the Compare Data Task Flow. Displays a form for generating a 
 
 This Task Flow can be configured from the `taskflow.config.ts` file in the `_config` directory of the generated template files.
 
-<CodeBlock language="ts" title="taskflow.config.ts">{ConfigJson}</CodeBlock>
+<CodeBlock language="ts" title="taskflow.config.ts">
+  {ConfigJson}
+</CodeBlock>

--- a/docs/docs/task-flows/contribute-data.mdx
+++ b/docs/docs/task-flows/contribute-data.mdx
@@ -3,7 +3,7 @@ title: 'Contribute Data'
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import ConfigJson from '!!raw-loader!../../../strudel-taskflows/src/pages/contribute-data/_config/taskflow.config';
+import ConfigJson from '!!raw-loader!../../../src/pages/contribute-data/_config/taskflow.config';
 
 # Contribute Data
 
@@ -61,7 +61,7 @@ User portal page of the Contribute Data Task Flow. Displays a list of the user's
 #### `new.tsx`
 
 **URL Route**: `/new`  
-New dataset page of the Contribute Data Task Flow. Displays a metadata form and data upload panel for adding new data contributions. 
+New dataset page of the Contribute Data Task Flow. Displays a metadata form and data upload panel for adding new data contributions.
 
 #### `review.tsx`
 
@@ -72,4 +72,6 @@ Review new dataset page of the Contribute Data Task Flow. Displays a preview of 
 
 This Task Flow can be configured from the `taskflow.config.ts` file in the `_config` directory of the generated template files.
 
-<CodeBlock language="ts" title="taskflow.config.ts">{ConfigJson}</CodeBlock>
+<CodeBlock language="ts" title="taskflow.config.ts">
+  {ConfigJson}
+</CodeBlock>

--- a/docs/docs/task-flows/explore-data.mdx
+++ b/docs/docs/task-flows/explore-data.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Explore Data"
+title: 'Explore Data'
 ---
 
-import CodeBlock from "@theme/CodeBlock";
-import ConfigJson from "!!raw-loader!../../../strudel-taskflows/src/pages/explore-data/_config/taskflow.config";
+import CodeBlock from '@theme/CodeBlock';
+import ConfigJson from '!!raw-loader!../../../src/pages/explore-data/_config/taskflow.config';
 
 # Explore Data
 

--- a/docs/docs/task-flows/monitor-activities.mdx
+++ b/docs/docs/task-flows/monitor-activities.mdx
@@ -3,7 +3,7 @@ title: 'Monitor Activities'
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import ConfigJson from '!!raw-loader!../../../strudel-taskflows/src/pages/monitor-activities/_config/taskflow.config';
+import ConfigJson from '!!raw-loader!../../../src/pages/monitor-activities/_config/taskflow.config';
 
 # Monitor Activities
 
@@ -57,4 +57,6 @@ Detail page of the Monitor Activities Task Flow. When a user drills into a recor
 
 This Task Flow can be configured from the `taskflow.config.ts` file in the `_config` directory of the generated template files.
 
-<CodeBlock language="ts" title="taskflow.config.ts">{ConfigJson}</CodeBlock>
+<CodeBlock language="ts" title="taskflow.config.ts">
+  {ConfigJson}
+</CodeBlock>

--- a/docs/docs/task-flows/run-computation.mdx
+++ b/docs/docs/task-flows/run-computation.mdx
@@ -3,7 +3,7 @@ title: 'Run Computation'
 ---
 
 import CodeBlock from '@theme/CodeBlock';
-import ConfigJson from '!!raw-loader!../../../strudel-taskflows/src/pages/run-computation/_config/taskflow.config';
+import ConfigJson from '!!raw-loader!../../../src/pages/run-computation/_config/taskflow.config';
 
 # Run Computation
 
@@ -76,4 +76,6 @@ Results page of the Run Computation Task Flow. Displays output data and visualiz
 
 This Task Flow can be configured from the `taskflow.config.ts` file in the `_config` directory of the generated template files.
 
-<CodeBlock language="ts" title="taskflow.config.ts">{ConfigJson}</CodeBlock>
+<CodeBlock language="ts" title="taskflow.config.ts">
+  {ConfigJson}
+</CodeBlock>

--- a/docs/docs/task-flows/search-data-repositories.mdx
+++ b/docs/docs/task-flows/search-data-repositories.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Search Data Repositories"
+title: 'Search Data Repositories'
 ---
 
-import CodeBlock from "@theme/CodeBlock";
-import ConfigJson from "!!raw-loader!../../../strudel-taskflows/src/pages/search-data-repositories/_config/taskflow.config";
+import CodeBlock from '@theme/CodeBlock';
+import ConfigJson from '!!raw-loader!../../../src/pages/search-data-repositories/_config/taskflow.config';
 
 # Search Data Repositories
 


### PR DESCRIPTION
The raw loader file paths in the docs need to be updated based on the new repo structure.