### PR TITLE
2i2c workshop hub

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+VITE_BASE_URL=/user/jnywong/proxy/absolute/5175/

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Push your code to the `my-repo` remote repository on GitHub with
 git push my-repo <branch-name>
 ```
 
-When pushing for the first time, this will trigger an authorization flow.
+When pushing for the first time, this will trigger a device flow. Follow the onscreen instructions to authorize your GitHub account.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ This library provides a suite of templates to implement UIs for various differen
 
 Pull the [strudel-kit](https://github.com/strudel-science/strudel-kit) repository from GitHub into the 2i2c workshop hub by clicking the following nbgitpuller link:
 
-- [nbgitpuller](https://strudel.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fstrudel-science%2Fstrudel-kit&urlpath=vscode%2F%3Ffolder%3D%2Fhome%2Fjovyan%2Fstrudel-kit&branch=main)
+- [nbgitpuller](https://strudel.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fstrudel-science%2Fstrudel-kit&urlpath=vscode%2F%3Ffolder%3D%2Fhome%2Fjovyan%2Fstrudel-kit&branch=workshop-hub)
 
 Log into the hub by choosing a username and entering the shared password for the workshop hub (ask your instructor for this password).
+
+> [!NOTE]  
+> Sessions on the workshop hub are culled after a 1 hour period of inactivity, and your work is not saved to a persistent storage disk. Please version control and [Push your code to GitHub](#push-your-code-to-github) for any work you would like to save for the future.
 
 Install the dependencies:
 
@@ -26,7 +29,7 @@ Start up the app:
 npm start
 ```
 
-Follow the port forwarding to [https://strudel.2i2c.cloud/user/<your-username>/proxy/absolute/5175/](https://strudel.2i2c.cloud/user-redirect/proxy/absolute/5175/) to view the app in the browser.
+Follow the port forwarding to [https://strudel.2i2c.cloud/user/<your-username>/proxy/absolute/5175/](https://strudel.2i2c.cloud/user-redirect/proxy/absolute/5175/) to view the app in another browser window.
 
 Begin modifying the templates in `src/pages`.
 
@@ -45,7 +48,7 @@ Once the repository is created, make a note of your GitHub remote HTTPS URL by c
 In the 2i2c workshop hub, add the remote repository you have just created with
 
 ```bash
-git remote add my-repo https://github.com/<your-username>/strudel-kit.git
+git remote add <remote-name> https://github.com/<your-username>/strudel-kit.git
 ```
 
 Git add any changes to the codebase as normal.
@@ -60,7 +63,7 @@ git config --global user.name "<your-github-username>"
 Push your code to the `my-repo` remote repository on GitHub with
 
 ```bash
-git push my-repo <branch-name>
+git push <remote-name> <branch-name>
 ```
 
 When pushing for the first time, this will trigger a device flow. Follow the onscreen instructions to authorize your GitHub account.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library provides a suite of templates to implement UIs for various differen
 
 ## Getting Started on the 2i2c Workshop Hub
 
-Pull the strudel-kit repository from GitHub into the 2i2c workshop hub by clicking the following nbgitpuller link:
+Pull the [strudel-kit](https://github.com/strudel-science/strudel-kit) repository from GitHub into the 2i2c workshop hub by clicking the following nbgitpuller link:
 
 - [nbgitpuller](https://strudel.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fstrudel-science%2Fstrudel-kit&urlpath=vscode%2F%3Ffolder%3D%2Fhome%2Fjovyan%2Fstrudel-kit&branch=main)
 
@@ -29,6 +29,41 @@ npm start
 Follow the port forwarding to [https://strudel.2i2c.cloud/user/<your-username>/proxy/absolute/5175/](https://strudel.2i2c.cloud/user-redirect/proxy/absolute/5175/) to view the app in the browser.
 
 Begin modifying the templates in `src/pages`.
+
+## Push your code to GitHub
+
+### Create a remote repository
+
+From the [strudel-kit](https://github.com/strudel-science/strudel-kit) GitHub repository, click on the _Use this template_ button to create your own copy of the code in your GitHub account.
+
+Choose a repository name, e.g. `strudel-kit`, and click _Create repository_.
+
+Once the repository is created, make a note of your GitHub remote HTTPS URL by clicking the _Code_ button, e.g. `https://github.com/<your-username>/strudel-kit.git`.
+
+### Add the remote repository in the 2i2c workshop hub
+
+In the 2i2c workshop hub, add the remote repository you have just created with
+
+```bash
+git remote add my-repo https://github.com/<your-username>/strudel-kit.git
+```
+
+Git add any changes to the codebase as normal.
+
+When signing your commits for the first time, you may need to set
+
+```bash
+git config --global user.email "<your-email-address>"
+git config --global user.name "<your-github-username>"
+```
+
+Push your code to the `my-repo` remote repository on GitHub with
+
+```bash
+git push my-repo <branch-name>
+```
+
+When pushing for the first time, this will trigger an authorization flow.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This library provides a suite of templates to implement UIs for various differen
 
 [Browse the Docs](https://strudel.science/strudel-kit/docs/)
 
-## Getting Started
+## Getting Started on the 2i2c Workshop Hub
 
-Clone the strudel-kit repository from github:
+Pull the strudel-kit repository from GitHub into the 2i2c workshop hub by clicking the following nbgitpuller link:
 
-```
-git clone git@github.com:strudel-science/strudel-kit.git
-```
+- [nbgitpuller](https://strudel.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fstrudel-science%2Fstrudel-kit&urlpath=vscode%2F%3Ffolder%3D%2Fhome%2Fjovyan%2Fstrudel-kit&branch=main)
+
+Log into the hub by choosing a username and entering the shared password for the workshop hub (ask your instructor for this password).
 
 Install the dependencies:
 
@@ -26,7 +26,7 @@ Start up the app:
 npm start
 ```
 
-Open [http://localhost:5175](http://localhost:5175) to view the app in the browser.
+Follow the port forwarding to [https://strudel.2i2c.cloud/user/<your-username>/proxy/absolute/5175/](https://strudel.2i2c.cloud/user-redirect/proxy/absolute/5175/) to view the app in the browser.
 
 Begin modifying the templates in `src/pages`.
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 5175,
       strictPort: true,
+      allowedHosts: ['.strudel.2i2c.cloud'],
     },
   };
 });


### PR DESCRIPTION
- README instructions for using the 2i2c workshop hub
- `vite.config.ts` updated to allow `strudel.2i2c.cloud` as an allowed host
- `.env.local` file to set `VITE_BASE_URL` environment variable