### PR TITLE
Add all-contributors spec

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,4 @@
+{
+  "projectName": "strudel-kit",
+  "projectOwner": "strudel-science"
+}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ degit strudel-science/strudel-kit/templates/explore-data/frontend/src/pages/comp
 
 STRUDEL Kit welcomes contributions of all kinds! Learn how to submit suggestions and changes in [CONTRIBUTING.md](https://github.com/strudel-science/strudel-kit/blob/main/CONTRIBUTING.md).
 
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
 ## License 
 
 This software is licensed through the [Lawrence Berkeley National Lab](https://www.lbl.gov/) and can be used, modified, and shared at absolutely no cost. [Read the full license](https://github.com/strudel-science/strudel-kit/blob/main/LICENSE).


### PR DESCRIPTION
Add the [all-contributors](https://allcontributors.org/) spec so that we can recognize all kinds of contributions to strudel-kit.